### PR TITLE
Allow to specifies multiple protocols to be tested

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ runners:
 - `path`: A [glob](https://www.npmjs.com/package/glob) pattern relative to the `mount` directory to match the snippets definition files.
 - `templates`: The directory where the snippets templates are located.
 - `dest` (optional): The default location to store templated snippets.
+- `protocols` (optional): A list of default protocols to tests for each snippets, if not present it is defaulted to `websocket` only, can be override per snippet config.
 
 #### runners
 
@@ -126,6 +127,7 @@ runners:
 
 - `snippet.dir`: the snippets directory
 - `snippet.source`: the rendered snippet file with its extension (i.e. `mySnippet.js`)
-- `snippet.name`: the rendered snippet file without its extension (i.e. `mySnippet`) 
+- `snippet.name`: the rendered snippet file without its extension (i.e. `mySnippet`)
+- `snippet.protocol` the protocol that should execute the snippet
 
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ runners:
 - `path`: A [glob](https://www.npmjs.com/package/glob) pattern relative to the `mount` directory to match the snippets definition files.
 - `templates`: The directory where the snippets templates are located.
 - `dest` (optional): The default location to store templated snippets.
-- `protocols` (optional): A list of default protocols to tests for each snippets, if not present it is defaulted to `websocket` only, can be override per snippet config.
+- `protocols` (optional): A list of default protocols to tests for each snippet, if not present it is defaulted to `websocket` only, can be override per snippet config.
 
 #### runners
 
@@ -129,5 +129,4 @@ runners:
 - `snippet.source`: the rendered snippet file with its extension (i.e. `mySnippet.js`)
 - `snippet.name`: the rendered snippet file without its extension (i.e. `mySnippet`)
 - `snippet.protocol` the protocol that should execute the snippet
-
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,7 +21,8 @@ class Suite {
       snippets: {
         dest: '/var/snippets',
         mount: '/mnt',
-        path: '**/snippets/*.test.yml'
+        path: '**/snippets/*.test.yml',
+        protocols: ['websocket']
       }
     });
 
@@ -103,13 +104,15 @@ class Suite {
       const runner = new Runner(this, runnerName, this.config.runners[runnerName]);
 
       for (const snippet of this.snippetsTree[runnerName]) {
-        try {
-          await runner.run(snippet);
-          this.services.logger.logSnippetSuccess(snippet);
-        } catch (e) {
-          snippet.display();
-          this.services.logger.logSnippetError(snippet, e);
-          process.exit(1);
+        for (const protocol of snippet.protocols) {
+          try {
+            await runner.run(snippet, protocol);
+            this.services.logger.logSnippetSuccess(snippet, protocol);
+          } catch (e) {
+            snippet.display();
+            this.services.logger.logSnippetError(snippet, protocol, e);
+            process.exit(1);
+          }
         }
       }
     }

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -152,14 +152,14 @@ class Runner {
    * @param {Snippet} snippet
    * @returns {Promise<ExecResult>}
    */
-  async run (snippet) {
+  async run (snippet, protocol) {
     await this.beforeRun();
 
     await this.build(snippet);
 
     await this._runHooks(snippet, 'before');
 
-    const exec = await this.container.exec(this._templateSnippetCommand(this.config.run.cmd, snippet));
+    const exec = await this.container.exec(this._templateSnippetCommand(this.config.run.cmd, snippet, protocol));
     if (exec.exitCode !== 0) {
       throw new TestError('RUN_ERR', exec.output);
     }
@@ -210,11 +210,12 @@ class Runner {
       .replace(/{{ snippet.dir }}/g, this.config.path);
   }
 
-  _templateSnippetCommand (cmd, snippet) {
+  _templateSnippetCommand (cmd, snippet, protocol) {
     return `cd ${snippet.destDir} && ` + cmd
       .replace(/{{ snippet.name }}/g, snippet.name)
       .replace(/{{ snippet.source }}/g, snippet.source)
-      .replace(/{{ snippet.dir }}/g, snippet.destDir);
+      .replace(/{{ snippet.dir }}/g, snippet.destDir)
+      .replace(/{{ snippet.protocol }}/g, protocol);
   }
 
   async _runHooks (snippet, type) {

--- a/lib/services/logger.js
+++ b/lib/services/logger.js
@@ -11,11 +11,11 @@ class Logger {
     this.suite = suite;
   }
 
-  logSnippetSuccess (snippet) {
+  logSnippetSuccess (snippet, protocol) {
     console.log(
       blue(`[${snippet.runner}]`),
       green('✔'),
-      green(`${snippet.name}: ${snippet.description}`)
+      green(`<${protocol}> ${snippet.name}: ${snippet.description}`)
     );
   }
 
@@ -23,11 +23,11 @@ class Logger {
    * @param {Snippet} snippet
    * @param {TestError} error
    */
-  logSnippetError (snippet, error) {
+  logSnippetError (snippet, protocol, error) {
     console.log(
       blue(`[${snippet.runner}]`),
       red('✗'),
-      yellow(`${snippet.name}: ${snippet.description}`)
+      yellow(`<${protocol}> ${snippet.name}: ${snippet.description}`)
     );
     console.log(red(error.code));
     console.log(red(error.message));

--- a/lib/snippet.js
+++ b/lib/snippet.js
@@ -24,6 +24,7 @@ class Snippet {
     this.expected = def.expected;
     this.template = def.template;
     this.runner = def.runner || config.runners.default;
+    this.protocols = def.protocols || config.snippets.protocols || ['websocket'];
 
     this.snippetFile = glob.sync(this.definitionFile.replace(/\.test\.yml$/, '.*'))
       .filter(f => !f.endsWith('.test.yml'))[0];


### PR DESCRIPTION
## What does this PR do ?

This PR enables us to specifies multiples protocols that the snippets should be tested with.
The snippet testing framework will then run the snippet for each different protocols that should be tested.

In the config.yml the snippets part has a new `protocols` field that can be used to defined the defaults protocols that the snippets should be tested with.
If not present this is defaulted to `websocket` only.

**Example of config.yml**
```yml
snippets:
  mount: /mnt
  path: doc/**/snippets/*.test.yml
  templates: /mnt/test/templates
  dest: /var/snippets
  protocols:
    - websocket
    - http
```

Each snippet can override the default configuration of the `config.yml` file by specifying the protocols themselves
**Example check-rights.test.yml**
```yml
name: auth#checkRights
description: <...>
hooks:
  before: <...>
  after: <...>
template: print-result
expected: true
protocols:
  - http
```
This tests will only be run for `http` while all the other that doesn't specifies their procotols will be run with the default `websocket` and `http`  from the previous config.

This PR also adds a new variable `{{ snippet.protocol }}` that will be replaced by the protocol that should be used to run the snippet.
This variable can be used to define an environment variable in the command that should run the snippet in the `config.yml`
**Example of config.yml**
```yml
    dart:
      service: <...>
      path: <...>
      build:
        cmd: <...>
      run:
        before: <...>
        cmd: SNIPPET_PROTOCOL={{ snippet.protocol }} dart {{ snippet.source }}
```
Like so for each protocol we will have a `SNIPPET_PROTOCOL` environment variable that is equal to the protocol that should be used. This environment variable can then be used in the templates to determine which protocol should be used.