### PR TITLE
Add debug capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,11 @@ runners:
 
 - `default`: which runner to use by default if not found in the `.test.yml` definition file.
 - `<runner>`:
+  - `debugStdout`: boolean telling to show what commands do write on stdout
+  - `debugStderr`: boolean telling to show what commands do write on stderr
   - `service`: the docker service name as defined in the `docker-compose.yml` file
   - `path`: the path where to render and find the snippets. Overrides `snippets.dest` if set.
+  - `afterInit`: command to execute after initialization is finished (executed only once)
   - `lint`:
     - `global`: if set to `true`, will run the lint command once only. Useful if all snippets can be lint at once.
     - `cmd`: the command to execute.

--- a/lib/index.js
+++ b/lib/index.js
@@ -69,7 +69,6 @@ class Suite {
       
       const container = this.services.docker.getContainer(runnerConfig.service);
       if (runnerConfig.afterInit) {
-        console.log(runnerConfig);
         await container.exec(runnerConfig.afterInit, {
           printStdout: true,
           printStderr: true,

--- a/lib/index.js
+++ b/lib/index.js
@@ -63,6 +63,19 @@ class Suite {
     }
 
     await this.services.init();
+
+    for (const runnerName of Object.keys(this.snippetsTree)) {
+      const runnerConfig = this.config.runners[runnerName];
+      
+      const container = this.services.docker.getContainer(runnerConfig.service);
+      if (runnerConfig.afterInit) {
+        console.log(runnerConfig);
+        await container.exec(runnerConfig.afterInit, {
+          printStdout: true,
+          printStderr: true,
+        });
+      }
+    }
   }
 
   render () {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -44,7 +44,12 @@ class Runner {
     const cmd = this._templateCommand(this.config.build.before);
 
     this.services.logger.logRunner(this, `build [before] hook: ${cmd}`);
-    const exec = await this.container.exec(this._templateCommand(cmd));
+    const exec = await this.container.exec(
+      this._templateCommand(cmd),
+      {
+        printStdout: this.config.debugStdout,
+        printStderr: this.config.debugStderr,
+      });
 
     if (exec.exitCode !== 0) {
       throw new TestError('BUILD_BEFORE_ERR', exec.output);
@@ -65,7 +70,12 @@ class Runner {
     const cmd = this._templateCommand(this.config.lint.before);
 
     this.services.logger.logRunner(this, `lint [before] hook: ${cmd}`);
-    const exec = await this.container.exec(this._templateCommand(cmd));
+    const exec = await this.container.exec(
+      this._templateCommand(cmd),
+      {
+        printStdout: this.config.debugStdout,
+        printStderr: this.config.debugStderr,
+      });
 
     if (exec.exitCode !== 0) {
       throw new TestError('LINT_BEFORE_ERR', exec.output);
@@ -86,7 +96,12 @@ class Runner {
     const cmd = this._templateCommand(this.config.run.before);
 
     this.services.logger.logRunner(this, `run [before] hook: ${cmd}`);
-    const exec = await this.container.exec(this._templateCommand(cmd));
+    const exec = await this.container.exec(
+      this._templateCommand(cmd),
+      {
+        printStdout: this.config.debugStdout,
+        printStderr: this.config.debugStderr,
+      });
 
     if (exec.exitCode !== 0) {
       throw new TestError('RUN_BEFORE_ERR', exec.output);
@@ -99,7 +114,12 @@ class Runner {
     await this.beforeLint();
 
     const cmd = this._templateCommand(this.config.lint.cmd);
-    const exec = await this.container.exec(cmd);
+    const exec = await this.container.exec(
+      cmd,
+      {
+        printStdout: this.config.debugStdout,
+        printStderr: this.config.debugStderr,
+      });
 
     if (exec.exitCode !== 0) {
       throw new TestError('LINT_ERR', `${cmd}\n${exec.output}`);
@@ -119,7 +139,12 @@ class Runner {
       return;
     }
 
-    const exec = await this.container.exec(this._templateSnippetCommand(this.config.lint.cmd, snippet));
+    const exec = await this.container.exec(
+      this._templateSnippetCommand(this.config.lint.cmd, snippet),
+      {
+        printStdout: this.config.debugStdout,
+        printStderr: this.config.debugStderr,
+      });
 
     if (exec.exitCode !== 0) {
       throw new TestError('LINT_ERR', exec.output);
@@ -139,7 +164,12 @@ class Runner {
       return;
     }
 
-    const exec = await this.container.exec(this._templateSnippetCommand(this.config.build.cmd, snippet));
+    const exec = await this.container.exec(
+      this._templateSnippetCommand(this.config.build.cmd, snippet),
+      {
+        printStdout: this.config.debugStdout,
+        printStderr: this.config.debugStderr,
+      });
 
     if (exec.exitCode !== 0) {
       throw new TestError('BUILD_ERR', exec.output);
@@ -159,7 +189,12 @@ class Runner {
 
     await this._runHooks(snippet, 'before');
 
-    const exec = await this.container.exec(this._templateSnippetCommand(this.config.run.cmd, snippet, protocol));
+    const exec = await this.container.exec(
+      this._templateSnippetCommand(this.config.run.cmd, snippet, protocol),
+      {
+        printStdout: this.config.debugStdout,
+        printStderr: this.config.debugStderr,
+      });
     if (exec.exitCode !== 0) {
       throw new TestError('RUN_ERR', exec.output);
     }
@@ -226,7 +261,12 @@ class Runner {
     const hooks = Array.isArray(snippet.hooks[type]) ? snippet.hooks[type] : [snippet.hooks[type]];
 
     for (const hook of hooks) {
-      const result = await this.container.exec(this._templateSnippetCommand(hook, snippet));
+      const result = await this.container.exec(
+        this._templateSnippetCommand(hook, snippet),
+        {
+          printStdout: this.config.debugStdout,
+          printStderr: this.config.debugStderr,
+        });
       if (result.exitCode !== 0) {
         throw new TestError(`ERR_HOOK_${type.toUpperCase()}`, `${hook}\n${result.output}`);
       }

--- a/lib/services/docker/container.js
+++ b/lib/services/docker/container.js
@@ -1,6 +1,8 @@
+const { chunk } = require('lodash');
 const
   streams = require('memory-streams'),
-  ExecResult = require('./execResult');
+  ExecResult = require('./execResult'),
+  { PassThrough } = require('stream');
 
 class Container {
   constructor(instance, info) {
@@ -12,7 +14,7 @@ class Container {
    * @param {string} cmd
    * @returns {Promise<ExecResult>}
    */
-  async exec (cmd) {
+  async exec (cmd, opts = { printStdout: false, printStderr: false }) {
     const exec = await this.instance.exec({
       Cmd: ['sh' , '-c', cmd],
       AttachStdout: true,
@@ -28,7 +30,24 @@ class Container {
         }
 
         const mStream = new streams.WritableStream();
-        this.instance.modem.demuxStream(stream, mStream, mStream);
+        const stdout = new PassThrough();
+        const stderr = new PassThrough();
+
+        stdout.on('data', chunk => {
+          if (opts.printStdout) {
+            process.stdout.write(chunk);
+          }
+          mStream.write(chunk);
+        });
+
+        stderr.on('data', chunk => {
+          if (opts.printStderr) {
+            process.stderr.write(chunk);
+          }
+          mStream.write(chunk);
+        });
+
+        this.instance.modem.demuxStream(stream, stdout, stderr);
 
         stream.on('end', () => {
           exec.inspect((e, out) => {


### PR DESCRIPTION
## What does this PR do ?

- Add new options that allows us to show the outputs of the stdout and stderr to debug the snippet tests (`debugStdout` and `debugStderr`)
- Add a new option `afterInit` that allows the execution of one command only once after the initialization of the runner